### PR TITLE
fix: update release workflow to remove README verification

### DIFF
--- a/.github/workflows/on-push-to-release.yaml
+++ b/.github/workflows/on-push-to-release.yaml
@@ -5,20 +5,8 @@ on:
     branches: [ release ]
 
 jobs:
-  verify-readme:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Verify README generation
-        uses: momentohq/standards-and-practices/github-actions/oss-readme-template@gh-actions-v1
-        with:
-          project_status: official
-          project_stability: alpha
-          project_type: other
   release:
     runs-on: ubuntu-latest
-    needs: [ verify-readme ]
     steps:
       - uses: actions/checkout@v3
       - name: Set release


### PR DESCRIPTION
We don't have README template to produce README for this repo, so removed README verification based on the template from the release worklfow.