### PR TITLE
fix: examples version bump for docker

### DIFF
--- a/docker/composer.json
+++ b/docker/composer.json
@@ -8,7 +8,7 @@
         "laravel/framework": "^9.19",
         "laravel/sanctum": "^3.0",
         "laravel/tinker": "^2.7",
-        "momentohq/laravel-example": "0.2.0"
+        "momentohq/laravel-example": "0.2.*"
     },
     "require-dev": {
         "fakerphp/faker": "^1.9.1",


### PR DESCRIPTION
Sets example project dependency for docker to the version I'm about to release.