### PR TITLE
chore: Update to API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,11 @@ Intrigued? Keep on reading!
 ## Run the app via Docker
 
 Before building a Docker image, create `.env` file in `docker` directory with the following env variables:
-- `MOMENTO_AUTH_TOKEN`=<YOUR_AUTH_TOKEN>
+- `MOMENTO_API_KEY`=<YOUR_API_KEY>
 - `MOMENTO_CACHE_NAME`=<YOUR_CACHE_NAME>
 - `WEATHER_API_KEY` this is for weather API. Check out [OpenWeather](https://openweathermap.org/) to get an API key.
 
-If you don't have a Momento auth token, you can generate one using the 
-[Momento CLI](https://github.com/momentohq/momento-cli) or our register for a token
-[on our website](https://www.gomomento.com/try-free).
+If you don't have a Momento API key, you can generate one using the [Momento Console](https://console.gomomento.com).
 
 Build a Docker image for the app:
 ```bash
@@ -77,11 +75,9 @@ Update the cache driver entry in your `.env` file:
 And add the following environment variables into your `.env` file:
 
 - `WEATHER_API_KEY` this is for weather API. Check out [OpenWeather](https://openweathermap.org/) to get an API key.
-- `MOMENTO_AUTH_TOKEN` 
+- `MOMENTO_API_KEY` 
 
-If you don't have a Momento auth token, you can generate one using the
-[Momento CLI](https://github.com/momentohq/momento-cli) or our register for a token
-[on our website](https://www.gomomento.com/try-free).
+If you don't have a Momento API key, you can generate one using the [Momento Console](https://console.gomomento.com).
 
 Run `composer update` to install the necessary prerequisites.
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.0.2",
         "guzzlehttp/guzzle": "^7.5",
-        "momentohq/laravel-cache": "v1.0.4"
+        "momentohq/laravel-cache": "v1.0.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Controllers/WeatherController.php
+++ b/src/Controllers/WeatherController.php
@@ -43,7 +43,7 @@ class WeatherController extends Controller
     public function zipcode($zipcode, $countryCode)
     {
         $configuration = Laptop::latest();
-        $authProvider = new EnvMomentoTokenProvider("MOMENTO_AUTH_TOKEN");
+        $authProvider = new EnvMomentoTokenProvider("MOMENTO_API_KEY");
         $momentoClient = new CacheClient($configuration, $authProvider, 60);
         $cacheName = "zipcode-cache";
         $momentoClient->createCache($cacheName);


### PR DESCRIPTION
Updated the word `auth token` to `API key`, and also updated the READM to direct users to use our console to generate an API key instead on our CLI which is deprecated.